### PR TITLE
Added TERM to exclude list

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,7 +10,8 @@ import (
 
 func main() {
   // This MUST remain in alphabetical order for contains to work
-  ignores := []string{ "GOLANG_VERSION", "GOPATH", "HOME", "HOSTNAME", "PATH", "no_proxy" }
+  ignores := []string{ "GOLANG_VERSION", "GOPATH", "HOME", "HOSTNAME", "PATH",
+                       "TERM", "no_proxy" }
 
   for _, e := range os.Environ() {
     pair := strings.Split(e, "=")


### PR DESCRIPTION
When I run the simulator, it creates a TERM secret (which happened to be set to xterm for me). This is not something I added myself, and I just upgraded to 17.09-ce, maybe that has something to do with it.